### PR TITLE
fix rake assets:precompile error

### DIFF
--- a/app/assets/javascripts/songs/index.js
+++ b/app/assets/javascripts/songs/index.js
@@ -70,7 +70,7 @@ $(function() {
   var showSongChords = function(songId, params) {
     var url = '/songs/' + songId + '.json';
 
-    $.get(url, params, function(data) {
+    $.getJSON(url, params, function(data) {
       var song = data.song;
       var chordSheet = song.chord_sheet;
       var artist = song.artist;


### PR DESCRIPTION
@natyconnor @leethomas 
After merged #19, I tried deploying to heroku but the deploy broke and exited on the `rake assets:precompile` step. You can repro for yourself with 

```
RAILS_ENV=production rake assets:precompile
```

I believe it's because of a bug in `songs/index.js` with default params not being available in ES5 (we are on ES5 not 6).
