### PR TITLE
override get method in link_to helper

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -12,9 +12,9 @@
           <a class="navbar-brand" href="#">GraceTunes</a>
         </div>
         <ul class="nav navbar-nav navbar-right ">
-          <li><%= link_to "Upload Song", new_song_path %></li>
-          <li><%= link_to "View Tags", tags_path %></li>
-          <li class="search-page"><%= link_to "Search", songs_path %></li>
+          <li><%= link_to "Upload Song", new_song_path, method: :get %></li>
+          <li><%= link_to "View Tags", tags_path, method: :get %></li>
+          <li class="search-page"><%= link_to "Search", songs_path, method: :get %></li>
           <li><a href="#">About</a></li>
         </ul>
       </div><!-- /.container -->


### PR DESCRIPTION
Fixes https://app.asana.com/0/search/211904750546389/196983703625956.

Caused by turbo links: http://stackoverflow.com/a/24211097