### PR TITLE
turn on config.force_ssl in production config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Anyone have any objections to forcing HTTPS? To be honest, I'm not 100% sure we need it because the Google authentication is handled by Google. But I do think without it, people's cookies could be stolen and used to log onto the site. Highly hypothetical but I heard some of our sites have been hacked before so I don't want to take any chances. Any other thoughts on security are highly appreciated.