### PR TITLE
pf/fix-background-image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.jpg filter=lfs diff=lfs merge=lfs -text

--- a/app/assets/stylesheets/controllers/_sessions.scss
+++ b/app/assets/stylesheets/controllers/_sessions.scss
@@ -2,7 +2,7 @@ $sign-in-logo-font-size: 55px;
 
 .sign-in {
   align-items: center;
-  background-image: image-url('guitar.jpg');
+  background-image: url('https://s28.postimg.org/5kyr8ulu3/guitar.jpg');
   background-position: center;
   background-size: cover;
   display: flex;


### PR DESCRIPTION
Since we run our app on Heroku and Heroku doesn't support git lfs according to [here](https://devcenter.heroku.com/articles/git) (search for git lfs), we can't use git lfs. Our options are either
1. Host in our repo, which will probably be the most reliable but will cause problems with our repo size in the future.
2. Host using postimg.org, which Winston already set up, which might be unreliable but will keep our repo clean and small and could potentially be faster (because it's on a different domain and could be using a CDN).
3. ???

Btw, @winstonkim , the image you picked is royalty free right?