### PR TITLE
Pf/reorder songs columns

### DIFF
--- a/db/migrate/20170104101534_reorder_songs_columns.rb
+++ b/db/migrate/20170104101534_reorder_songs_columns.rb
@@ -1,7 +1,7 @@
 class ReorderSongsColumns < ActiveRecord::Migration
   def change
     drop_table :songs
-    # associated indexes automatically removed?
+    # associated indices automatically removed
 
     create_table "songs", force: :cascade do |t|
       t.datetime "created_at",    null: false
@@ -15,6 +15,9 @@ class ReorderSongsColumns < ActiveRecord::Migration
       t.text     "lyrics",        null: false
     end
 
-    # readd columns
+    # add indices back in
+    add_index "songs", ["artist"], name: "index_songs_on_artist", using: :gin
+    add_index "songs", ["lyrics"], name: "index_songs_on_lyrics", using: :gin
+    add_index "songs", ["name"], name: "index_songs_on_name", using: :gin
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161120224823) do
+ActiveRecord::Schema.define(version: 20170104101534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,15 +28,15 @@ ActiveRecord::Schema.define(version: 20161120224823) do
   add_index "song_tags", ["tag_id"], name: "index_song_tags_on_tag_id", using: :btree
 
   create_table "songs", force: :cascade do |t|
-    t.string   "name",          null: false
-    t.string   "key",           null: false
-    t.string   "artist"
-    t.text     "chord_sheet",   null: false
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.string   "name",          null: false
+    t.string   "key",           null: false
     t.string   "tempo",         null: false
-    t.text     "lyrics",        null: false
+    t.string   "artist"
     t.string   "standard_scan"
+    t.text     "chord_sheet",   null: false
+    t.text     "lyrics",        null: false
   end
 
   add_index "songs", ["artist"], name: "index_songs_on_artist", using: :gin


### PR DESCRIPTION
Sorry if I'm being borderline-OCD, but the order of the columns in the DB was really bothering me and I figured I'd reorder them before it becomes really painful to after we add all the songs to the prod DB.

Once/if this gets merged, you can always `rake db:migrate` to get the changes up but just to be safe, I'd drop the DBs and `rake db:schema:load`.

Oh, and I'm aware there is a way to reorder columns without deleting the entire table in MySQL, but that feature is not supported on Postgres. Apparently the Postgres developers are too lazy. Haha I guess they are all less OCD than I am about the order of the columns.