### PR TITLE
swap key and tempo columns on songs dataTable

### DIFF
--- a/app/assets/javascripts/songs/index.js
+++ b/app/assets/javascripts/songs/index.js
@@ -10,8 +10,8 @@ $(function() {
     columns: [
       { data: 'name' },
       { data: 'artist' },
-      { data: 'tempo' },
       { data: 'key' },
+      { data: 'tempo' },
     ],
     createdRow: function(row, data, index) {
       $(row).data('song-id', data.id);

--- a/app/views/songs/index.html.erb
+++ b/app/views/songs/index.html.erb
@@ -27,8 +27,8 @@
             <tr>
               <th>Name</th>
               <th>Artist</th>
-              <th>Tempo</th>
               <th>Key</th>
+              <th>Tempo</th>
             </tr>
           </thead>
         </table>


### PR DESCRIPTION
On the preview panel and for the song filters (the things on the top right of the dataTable), the order of these two fields is key-tempo. But on the songs dataTable, the order is tempo-key. I think it makes sense to reorder right?