### PR TITLE
Check line lengths script

### DIFF
--- a/lib/tasks/manage_song_sheets.rake
+++ b/lib/tasks/manage_song_sheets.rake
@@ -30,6 +30,7 @@ namespace :songsheets do
       if lines_too_long.any?
         puts "#{File.basename(song_file, '.txt')}"
         lines_too_long.reverse.each do |line_number|
+          # print line numbers bottom up so as lines are split in two, the next line numbers are not affected
           puts "\t#{line_number}"
         end
         num_lines_too_long += lines_too_long.length


### PR DESCRIPTION
Script that checks for lines in a directory of song sheets that are too long.

Here's a sample run and output.
```
rake songsheets:check_line_lengths[GraceTunesSongs]
Commission My Soul
	54
	36
Everlasting God
	13
Filled With Your Glory
	54
	47
	30
	29
	18
	12
God and God Alone
	47
	46
	41
	40
	26
	24
God Be Praised
	50
	43
It Is Well With My Soul
	57
	55
	53
Let Me Be
	8
My Reward
	58
My Story
	74
	53
	31
	19
	15
	11
Potters Hand
	24
Your Love Awakens Me
	57
	46
	44
	26
	21
	18
	14
Done. There were 36 lines over 47 chars long.
```