### PR TITLE
Prevent duplicate songs

### DIFF
--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -14,8 +14,7 @@ class Song < ActiveRecord::Base
 
   before_validation :normalize
 
-  validates :name, presence: true
-  validates_uniqueness_of :name, scope: [:artist, :tempo], message: "is already taken by another song with the same artist and tempo"
+  validates :name, presence: true, uniqueness: { scope: :artist, message: "is taken by another song by this artist" }
   validates :key, presence: true
   validates_inclusion_of :key, in: VALID_KEYS, if: -> (song) { song.key.present? }
   validates :tempo, presence: true

--- a/db/migrate/20170312211307_add_unique_constraint_to_songs.rb
+++ b/db/migrate/20170312211307_add_unique_constraint_to_songs.rb
@@ -1,6 +1,6 @@
 class AddUniqueConstraintToSongs < ActiveRecord::Migration
   def change
-    add_index :songs, [:name, :artist, :tempo], unique: true
+    add_index :songs, [:name, :artist], unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 20170312211307) do
 
   add_index "songs", ["artist"], name: "index_songs_on_artist", using: :gin
   add_index "songs", ["lyrics"], name: "index_songs_on_lyrics", using: :gin
-  add_index "songs", ["name", "artist", "tempo"], name: "index_songs_on_name_and_artist_and_tempo", unique: true, using: :btree
+  add_index "songs", ["name", "artist"], name: "index_songs_on_name_and_artist", unique: true, using: :btree
   add_index "songs", ["name"], name: "index_songs_on_name", using: :gin
 
   create_table "tags", force: :cascade do |t|

--- a/test/models/song_test.rb
+++ b/test/models/song_test.rb
@@ -118,18 +118,29 @@ class SongTest < ActiveSupport::TestCase
     assert_equal(num_lyric_lines, 18)
   end
 
-  test "should not save songs with the same name, artist, and tempo" do
+  test "should not allow two songs with the same name and artist" do
     existing_song = songs(:glorious_day)
     new_song = Song.new(
       name: existing_song.name,
       artist: existing_song.artist,
-      tempo: existing_song.tempo,
+      tempo: Song::VALID_TEMPOS.first,
       key: Song::VALID_KEYS.first,
       chord_sheet: "testing"
     )
-    assert_not new_song.save, "Saved a duplicate song with the same name, artist, and tempo"
+    assert_not new_song.save, "Saved a duplicate song with the same name and artist"
   end
 
+  test "should allow two songs with the same name but different artists" do
+    existing_song = songs(:glorious_day)
+    new_song = Song.new(
+      name: existing_song.name,
+      artist: existing_song.artist + " testing", # make sure artist is different
+      tempo: Song::VALID_TEMPOS.first,
+      key: Song::VALID_KEYS.first,
+      chord_sheet: "testing"
+    )
+    assert new_song.save, "Did not allow two songs with the same name but different artist"
+  end
   # full text search tests
   single_word_results = Song.search_by_keywords "relevant"
   multi_word_results = Song.search_by_keywords "truth live life hands"


### PR DESCRIPTION
Changes
1. Added a validation to ensure no song is saved with the same name and artist as an existing song.
2. Refactored the validations so that normalize happens before validations (important so that name and artist gets normalized when we check for uniqueness). This required adding null-checks to the `normalize` method. Also reorganized the validations a bit so the validations for the same field are together.
3. Added a unique index to the DB. This is used in addition to the app-level constraint to catch duplicate songs created directly through the DB (not sure when they might happen but better safe than sorry for a small performance hit).