### PR TITLE
Fix search link not active when on root path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,13 @@
 Rails.application.routes.draw do
-  
-  root 'songs#index'
+
+  root to: redirect('/songs')
 
   resources :songs do
     member do
       get 'print'
     end
   end
-  
+
   resources :tags
 
   # Authentication


### PR DESCRIPTION
The bug: `current_page?` doesn't identify "/songs" as the same thing as "/" even though they route to the same controller and action. The reason is that it is comparing urls.

Two potential solutions
1. The first one is in my first commit: modify the `set_active_if_path` to take in multiple paths and check if at least one of them is true. I thought it was pretty elegant until I realized I couldn't think of another time where we would want to set a nav-link as active for multiple different urls.
2. Identify pages by controller name and action name. Less elegant, more verbose, but I think it makes a bit more sense and is clearer.

LMK what you guys think.