### PR TITLE
add standard scan to the songs#show page

### DIFF
--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -12,7 +12,10 @@
     <% end %>
   </div>
   <div class="song-metadata">
-    <span>Recommended Key: <span class="key"><%= @song.key %></span></span>&nbsp;&nbsp;|&nbsp;&nbsp;<span>Tempo: <%= @song.tempo %></span>
+    <span><strong>Suggested Key:</strong> <span class="key"><%= @song.key %></span></span>&nbsp;&nbsp;|&nbsp;&nbsp;<span><strong>Tempo:</strong> <%= @song.tempo %></span>
+     <% if @song.standard_scan.present? %>
+       <div><strong>Standard Scan:</strong> <%= @song.standard_scan %></div>
+     <% end %>
   </div>
 
   <div>

--- a/test/controllers/songs_controller_test.rb
+++ b/test/controllers/songs_controller_test.rb
@@ -38,6 +38,17 @@ class SongsControllerTest < ApplicationControllerTest
     assert_includes(songs_data, songs(:glorious_day))
   end
 
+  # "show" action tests
+  test "show song page should display the standard scan when it is not blank" do
+    get :show, id: songs(:forever_reign).id
+    assert_select ".song-metadata", /Standard Scan:/, "Standard scan should appear if it is not blank"
+  end
+
+  test "show song page should not display the standard scan when it is blank" do
+    get :show, id: songs(:relevant_1).id
+    assert_select ".song-metadata", {text: /Standard Scan:/, count: 0}, "Standard scan should not appear if it is blank"
+  end
+
   # "new" action tests
   test "new song page should load successfully if logged in as praise member" do
     get_edit_privileges

--- a/test/fixtures/songs.yml
+++ b/test/fixtures/songs.yml
@@ -89,6 +89,7 @@ forever_reign:
   artist: "Hillsong Worship"
   key: "C"
   tempo: "Medium"
+  standard_scan: "V1. V2. C. V3. C. C. B. C. C. C."
   chord_sheet: |
     Verse 1:
               C
@@ -187,6 +188,7 @@ ten_thousand_reasons:
   artist: "Matt Redman"
   key: "G"
   tempo: "Medium"
+  standard_scan: "I. C1. V1. C1. V2. C1. V3. C1. C2. T."
   chord_sheet: |
     Chorus:
               F          C     G/B Am


### PR DESCRIPTION
Restyled the show page a bit while adding the show songs page. Added tests and updated two fixtures to also contain standard scans.