### PR TITLE
Add link for feedback

### DIFF
--- a/app/assets/images/guitar.jpg
+++ b/app/assets/images/guitar.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d2735bd63ffcd692e6bb4a4dd1fb3a4ba2f36683c336687f1e13567bc86d882
-size 3255375

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -17,7 +17,7 @@
     <% end %>
     <div class="header_link">
       <%= link_to ENV['FEEDBACK_URL'], target: "_blank" do %>
-        <i class="fa fa-comment"></i>Contact
+        <i class="fa fa-comment"></i>Feedback
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Steven says we're about to go live this coming week (like announce to all of GP). He asked if we could have a place to receive feedback. Hence, I want to add a new link to the nav-bar that goes to a Google form where we can receive feedback.

1. I know for most websites, the Contact/Feedback link is generally not very prominent but at the bottom of the page in small font. However, I didn't do that because I didn't have time to design a new footer. I also think it's not that bad since the we are in beta and we do want lots of feedback, so it's okay if the Contact link is more prominent. LMK if you guys are against this.
2. I didn't hard code the link to the Google form but made it an environment variable that you have to set. I did this because I feel like hardcoding links to other websites can be a bad idea. But does this make it overly complicated?

Please give feedback sooner rather than later so we can release GraceTunes sooner :D

In case you're curious, the Google form is at https://docs.google.com/a/gpmail.org/forms/d/e/1FAIpQLSegoVnPJYmNTDHiCVJxBEk515GQGlVCQ_ny0ONedWdBtu7cLQ/viewform?usp=sf_link