### PR TITLE
Make section headers always uppercase

### DIFF
--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -44,7 +44,7 @@ class Song < ActiveRecord::Base
     end
 
     if chord_sheet
-      self.chord_sheet = chord_sheet.split("\n").each do |line|
+      self.chord_sheet = chord_sheet.split("\n").map do |line|
         if Parser.header?(line)
           line = line.upcase
         end

--- a/test/fixtures/songs.yml
+++ b/test/fixtures/songs.yml
@@ -3,7 +3,7 @@
 
 God_be_praised:
   name: "God Be Praised"
-  artist: "Elevation Worship":
+  artist: "Elevation Worship"
   key: "D"
   tempo: "Slow"
   chord_sheet: |

--- a/test/models/song_test.rb
+++ b/test/models/song_test.rb
@@ -82,6 +82,13 @@ class SongTest < ActiveSupport::TestCase
     assert_equal(song.chord_sheet, "     E                            G#m")
   end
 
+  test "should uppercase header lines" do
+    song = songs(:glorious_day)
+    song.chord_sheet = "this is a header:"
+    assert song.save, "Song was not saved successfully"
+    assert_equal(song.chord_sheet, "THIS IS A HEADER:", "Header not uppercased")
+  end
+
   test "never leaves lyrics field blank" do
     song = songs(:God_be_praised)
     song.lyrics = nil
@@ -102,7 +109,7 @@ class SongTest < ActiveSupport::TestCase
     song = songs(:all_my_hope)
     force_lyrics_extraction(song)
     assert_no_match(/Verse \d:/, song.lyrics, "Lyrics contained verse headers")
-    assert_not_includes(song.lyrics, "Chorus:", "Lyrics contained chorus header")
+    assert_not_includes(song.lyrics, "CHORUS:", "Lyrics contained chorus header")
   end
 
   test "extracted lyrics don't contain chords" do


### PR DESCRIPTION
https://app.asana.com/0/302764623142208/302764623142209

Regarding the style of headers, Steven and I decided to use
`SECTION HEADER:`
instead of
`Section Header:`

**Deploy Notes**
After this is merged, I plan on updating all the songs in prod by iterating through them in the rails console and re-saving them to force them through the normalization process.