### PR TITLE
use Rack::Timeout to abort requests taking too long and raise an exception

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'autoprefixer-rails'
 
 # Use Unicorn as the app server
 gem 'unicorn'
+gem 'rack-timeout'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
+    rack-timeout (0.4.2)
     rails (4.2.8)
       actionmailer (= 4.2.8)
       actionpack (= 4.2.8)
@@ -206,6 +207,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   pg
   pg_search
+  rack-timeout
   rails (= 4.2.8)
   rails_12factor
   sass-rails (~> 5.0)

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,0 +1,1 @@
+Rack::Timeout.service_timeout = 12  # seconds


### PR DESCRIPTION
Having a stacktrace on timing out would have saved me 30+ minutes debugging when songs wouldn't save because the Chords Regex froze. 

[Heroku](https://devcenter.heroku.com/articles/rails-unicorn#timeouts) recommends using the Rack::Timeout gem for this.

Also lower the timeout to 12 seconds. Rationale: lower it because we don't really do anything resource intensive but keep it relatively high because we only have one machine handling all the requests.