### PR TITLE
add option of number before modifier in regex and add test

### DIFF
--- a/app/services/parser.rb
+++ b/app/services/parser.rb
@@ -1,7 +1,7 @@
 # based off of https://gist.github.com/andrewstucki/106c9704be9233e197350ceabec6a32c
 module Parser
 
-  CHORD_LINE_REGEX = /^(?:\s*\(?(?:(?:(?:[A-G]|I{1,3}|IV|V|VI|VII|i{1,3}|iv|v|vi|vii)[#b]?(?:m|maj|dim)?(?:no|add|s|sus|aug)?\d?)|\/|(?:\([b#]?\d?\)))\)?\s*)+$/
+  CHORD_LINE_REGEX = /^(?:\s*\(?(?:(?:(?:[A-G]|I{1,3}|IV|V|VI|VII|i{1,3}|iv|v|vi|vii)[#b]?(?:m|maj|dim)?\d?(?:no|add|s|sus|aug)?\d?)|\/|(?:\([b#]?\d?\)))\)?\s*)+$/
   CHORD_TOKENIZER = /(?:\(?(?:[A-G](?:b)?(?:#)?(?:|maj|m|dim)?(?:|s|sus|aug)*[\d]*)\(?(?:b)?(?:#)?[\d]*?\)?\(?(?:b)?(?:#)?[\d]*?\)?)(?=\/|\s|$)/
   BASE_NOTE_REGEX = /[A-G][b#]?/
   MINOR_CHORD_REGEX = /(?<!di)m(?!aj)/

--- a/test/services/parser_test.rb
+++ b/test/services/parser_test.rb
@@ -18,6 +18,7 @@ class ParserTest < ActiveSupport::TestCase
     assert Parser.chords_line?("Em7   D#2     B9")
     assert Parser.chords_line?("Cmaj7       Ebmaj3      D#maj5")
     assert Parser.chords_line?("    Eb      Gbaug   ")
+    assert Parser.chords_line?("  A7sus        Fm7sus       G#msus")
     assert Parser.chords_line?("Em7/G#       F/Cmaj7        D/Cb3")
     assert Parser.chords_line?("A(5)     B(7)")
     assert Parser.chords_line?("D(b5)         E(#)")


### PR DESCRIPTION
Wayland found a bug where the regex doesn't support numbers before modifiers, ie `Am7sus`. Simple addition to the regex and a test for it.