### PR TITLE
make sure focused pill link text stays white

### DIFF
--- a/app/assets/stylesheets/modules/_pill.scss
+++ b/app/assets/stylesheets/modules/_pill.scss
@@ -5,6 +5,10 @@
 	padding: ($default-padding / 4) ($default-padding / 2);
   text-transform: uppercase;
 
+  &:focus {
+    color: $white
+  }
+
   &.pill_link-red {
     background: $red;
     display: inline-block;


### PR DESCRIPTION
![screen shot 2017-10-09 at 5 53 21 pm](https://user-images.githubusercontent.com/1967248/31367166-3c2914fc-ad2a-11e7-9ee0-f85c61dd75f0.png)
Trying to prevent this bug, where dark-blue pills are focused and the text inside of them also becomes dark blue. For uniformity, I prevented this behavior for all pills