### PR TITLE
add rake task for defragmenting ids

### DIFF
--- a/lib/tasks/song_sheets.rake
+++ b/lib/tasks/song_sheets.rake
@@ -39,7 +39,7 @@ def serialize_song_sheets(directory_path, save_into_db=false)
   puts "Done #{save_into_db ? "saving" : "validating"} songs. There were #{num_invalid_songs} invalid songs."
 end
 
-namespace :songsheets do
+namespace :song_sheets do
 
   desc 'Validate the format of all the yaml song sheets in a directory.'
   task :validate, [:directory_path] => :environment do |t, args|

--- a/lib/tasks/songs.rake
+++ b/lib/tasks/songs.rake
@@ -1,0 +1,23 @@
+# Turns off record_timestamps temporarily so that the updated_at field
+# will not be touched. Preserves current order of songs.
+def defragment_ids
+  begin
+    ActiveRecord::Base.record_timestamps = false
+    current_id = 1
+    # find_each retrives songs in order of "id ASC"
+    Song.find_each do |song|
+      song.id = current_id
+      song.save!
+      current_id += 1
+    end
+  ensure
+    ActiveRecord::Base.record_timestamps = true
+  end
+end
+
+namespace :songs do
+  desc 'Degragment song ids so that the lowest id starts at 1 and there are no gaps.'
+  task :defrag_ids  => :environment do |t, args|
+    defragment_ids()
+  end
+end


### PR DESCRIPTION
I want to run this on prod. Already tested it on staging and I confirm the order of the songs is preserved as well as the `updated_at` timestamp.