### PR TITLE
Revert "only show songs with > 0 views when sorting by 'Most Popular First'"

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -18,21 +18,19 @@ class SongsController < ApplicationController
         songs = songs.where(tempo: params[:tempo]) if params[:tempo].present?
         songs = songs.select('id, artist, tempo, key, name, chord_sheet, spotify_uri')
 
+        # store total number of songs after filtering
+        recordsFiltered = songs.length
+
         # reorder
         songs = case params[:sort]
         when 'Newest First'
           songs.reorder(created_at: :desc)
         when 'Most Popular First'
-          songs
-            .where.not(view_count: 0)
-            .reorder(view_count: :desc)
+          songs.reorder(view_count: :desc)
         else
           # does nothing if search_by_keywords was run, in which case songs are already ordered by relevance
           songs.order(name: :asc)
         end
-
-        # store total number of songs after all filtering is done
-        recordsFiltered = songs.length
 
         # paginate
         if params[:start].present?

--- a/test/controllers/songs_controller_test.rb
+++ b/test/controllers/songs_controller_test.rb
@@ -36,20 +36,6 @@ class SongsControllerTest < ApplicationControllerTest
     assert_equal(songs(:God_be_praised), songs_data[1])
   end
 
-  test "index should not return songs with zero view count when ordering by popularity" do
-    get :index, params: {
-      search: { value: "hope" },
-      sort: 'Most Popular First',
-      format: :json,
-      xhr: true
-    }
-
-    songs_data = load_songs
-
-    assert_includes(songs_data, songs(:God_be_praised))
-    assert_not_includes(songs_data, songs(:all_my_hope))
-  end
-
   test "index should be able to return songs ordered by date created" do
     get :index, params: {
       sort: 'Newest First',

--- a/test/fixtures/songs.yml
+++ b/test/fixtures/songs.yml
@@ -508,7 +508,6 @@ all_my_hope:
     Your love never ending
     Your grace never failing
     Redemption is calling us home
-  view_count: 0
 
 when_i_think_about_the_lord:
   created_at: "2018-01-01 00:00:00"


### PR DESCRIPTION
Reverts GracepointMinistries/GraceTunes#111.
Reverting because after some thought I realized it's confusing and misleading to have a sort button that also filters. It's not documented anywhere that it filters and someday someone will wonder why the song they were looking for disappeared when they were sorting by most popular, or completely miss the song they would have used!