### PR TITLE
Initial stab at a REST API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,12 @@ ruby '2.5.7'
 
 gem 'audited', '~> 4.6'
 gem 'autoprefixer-rails'
+gem 'cancancan', '~> 3.0.2'
 gem 'bootstrap-sass', '~> 3.4.1'
 gem 'bootstrap-will_paginate'
 gem 'diffy'
 gem 'font-awesome-rails'
+gem 'google-id-token', '~> 1.4.2'
 gem 'jbuilder', '~> 2.5' # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jquery-datatables-rails', '~> 3.4.0' # Use datatables for rendering and searching songs
 gem 'jquery-rails' # Use jquery as the JavaScript library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
       will_paginate
     builder (3.2.3)
     byebug (10.0.2)
+    cancancan (3.0.2)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
     diffy (3.2.0)
@@ -66,6 +67,8 @@ GEM
       railties (>= 3.2, < 6.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google-id-token (1.4.2)
+      jwt (>= 1)
     hashie (3.6.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
@@ -251,8 +254,10 @@ DEPENDENCIES
   bootstrap-sass (~> 3.4.1)
   bootstrap-will_paginate
   byebug
+  cancancan (~> 3.0.2)
   diffy
   font-awesome-rails
+  google-id-token (~> 1.4.2)
   jbuilder (~> 2.5)
   jquery-datatables-rails (~> 3.4.0)
   jquery-rails
@@ -285,4 +290,4 @@ RUBY VERSION
    ruby 2.5.7p206
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -1,0 +1,82 @@
+module API
+  module V2
+    class AuthenticationError < StandardError
+    end
+
+    class APIController < ActionController::API
+      include CanCan::ControllerAdditions
+
+      # Enforce authentication for every request
+      before_action :authn_check
+
+      # Enforce authorization for every request
+      load_and_authorize_resource
+
+      def initialize
+        @google_id_token_validator = GoogleIDToken::Validator.new
+      end
+
+      def current_user
+        @current_user
+      end
+
+      # Authentication consists checking the Authorization header for a JWT bearer token, and cryptographically verifying
+      # that the token:
+      # 1. was issued, signed by Google's OAuth2 service
+      # 2. has not expired
+      # 3. was issued for the appropriate audience (our app's Google OAuth2 client ID)
+      # 4. was issued for a user within the appropriate hosted domain (gpmail.org)
+      def authn_check
+        begin
+          auth_header = request.headers['Authorization']
+
+          if auth_header == nil?
+            raise RuntimeError, 'Missing Authorization header'
+          end
+
+          type, token = auth_header.split(' ')
+
+          if type != 'Bearer' || token.nil?
+            raise RuntimeError, 'Authorization header missing bearer token'
+          end
+
+          payload = @google_id_token_validator.check(token, ENV.fetch('GOOGLE_CLIENT_ID'))
+
+          name = payload.fetch('name')
+          email = payload.fetch('email')
+          hd = payload.fetch('hd')
+
+          if hd != 'gpmail.org'
+            raise RuntimeError, "Invalid hosted domain: #{hd}"
+          end
+
+          @current_user = User.find_by_email(email) || User.create(email: email, name: name, role: Role::READER)
+        rescue Exception => e
+          raise AuthenticationError, e.message
+        end
+      end
+
+      # 404
+      rescue_from ActiveRecord::RecordNotFound do |e|
+        render json: {error: 'Not found'}, status: :not_found
+      end
+
+      # 401
+      rescue_from AuthenticationError do |e|
+        render json: {error: e.message}, status: :unauthorized
+      end
+
+      # 403
+      rescue_from CanCan::AccessDenied do |e|
+        render json: {error: e.message}, status: :forbidden
+      end
+
+      # 400
+      rescue_from ActiveModel::ForbiddenAttributesError, ActiveRecord::RecordInvalid do |e|
+        render json: {error: e.message}, status: :bad_request
+      end
+    end
+  end
+end
+
+

--- a/app/controllers/api/v2/songs_controller.rb
+++ b/app/controllers/api/v2/songs_controller.rb
@@ -1,0 +1,34 @@
+# Songs controller
+class API::V2::SongsController < API::V2::APIController
+  # GET /
+  def index
+    render json: @songs
+  end
+
+  # POST /
+  def create
+    render json: Song.create!(song_params), status: :created
+  end
+
+  # GET /:id
+  def show
+    render json: @song
+  end
+
+  # PUT /:id
+  def update
+    @song.update!(song_params)
+    render json: @song
+  end
+
+  # DELETE /:id
+  def destroy
+    @song.destroy!
+    head :no_content
+  end
+
+  def song_params
+    params.require(:song)
+        .permit(:name, :artist, :key, :tempo, :chord_sheet, :bpm, :spotify_uri)
+  end
+end

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -1,0 +1,38 @@
+# Users controller
+class API::V2::UsersController < API::V2::APIController
+  def me
+    render json: @current_user
+  end
+
+  # GET /
+  def index
+    render json: @users
+  end
+
+  # POST /
+  def create
+    render json: User.create!(user_params), status: :created
+  end
+
+  # GET /:id
+  def show
+    render json: @user
+  end
+
+  # PUT /:id
+  def update
+    @user.update!(user_params)
+    render json: @user
+  end
+
+  # DELETE /:id
+  def destroy
+    @user.destroy!
+    head :no_content
+  end
+
+  def user_params
+    params.require(:user)
+        .permit(:email, :name, :role)
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,22 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Everyone: RUD themselves
+    can [:read, :update, :destroy], ::User do |subject|
+      subject.id == user.id
+    end
+
+    case user.role
+    when Role::ADMIN
+      # Admins: CRUD anything
+      can :manage, :all
+    when Role::PRAISE
+      # Praise members: CRU songs
+      can [:create, :read, :update], ::Song
+    when Role::READER
+      # Readers: R songs
+      can :read, ::Song
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,9 +21,15 @@ Rails.application.routes.draw do
   get 'signout', to: 'sessions#destroy', as: 'sign_out'
   get 'signin', to: 'sessions#new', as: 'sign_in'
 
-  # Mobile API
+  # API
   namespace :api, defaults: {format: :json} do
     get 'songs', to: 'songs#recently_updated'
     get 'songs/deleted', to: 'songs#deleted'
+
+    namespace :v2 do
+      resources :songs
+      resources :users
+      get 'whoami', to: 'users#me'
+    end
   end
 end

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,9 +23,6 @@ services:
       RAILS_ENV: development
       API_USERNAME: username
       API_PASSWORD: password
-      # Sourced from .env file
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       FEEDBACK_URL: https://docs.google.com/a/gpmail.org/forms/d/e/1FAIpQLSegoVnPJYmNTDHiCVJxBEk515GQGlVCQ_ny0ONedWdBtu7cLQ/viewform
       REQUEST_SONG_URL: https://docs.google.com/forms/d/e/1FAIpQLSe4zko5wg2FfTfTGGAVENnARWfg-4AJSQqz54BlWdagBhKISA/viewform
     ports:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,11 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Forward env variables, fail on errors
 set -aeu
 
 cp -r /src/* .
+
+[[ -f .env ]] && . .env
 
 bundle install
 bundle exec rails db:setup


### PR DESCRIPTION
# REST API for GraceTunes:

## v2

The existing API relies on [HTTP basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Basic_authentication_scheme), which is insecure and doesn't allow for federated authentication (e.g., [OAuth2](https://oauth.net/2)).

It also doesn't really provide robust REST interface for all the resources in GraceTunes.

To avoid breaking changes to this existing API, the new API will be accessed from routes starting with `/api/v2`.

## Design

### Interface

Each GraceTunes resource (e.g., user, song) associated with a REST resource, so endpoints are structured according to idiomatic REST principles, with a basic CRUDL interface.

E.g.:

```http
GET /api/v2/users
POST /api/v2/users
GET /api/v2/users/{id}
PUT /api/v2/users/{id}
DELETE /api/v2/users/{id}

GET /api/v2/songs
POST /api/v2/songs
GET /api/v2/songs/{id}
PUT /api/v2/songs/{id}
DELETE /api/v2/songs/{id}
```

### Authentication

Authn is completely stateless (no cookies or sessions) and [JWT](https://jwt.io) based.

Clients authenticate with [Google OAuth2](https://developers.google.com/identity/protocols/oauth2) to obtain a JWT token, an authenticate themselves to the GraceTunes v2 API by including it as a [Bearer Token](https://oauth.net/2/bearer-tokens) in the `Authorization` header with each request.

For each request, the GraceTunes v2 API verifies that the included token was issued and signed by Google, has not expired, was issued for us as the intended audience, and bears the identity of a user permitted to access our service (in current case, someone living in the hosted domain gpmail.org).

#### Try it out

Go to https://developers.google.com/oauthplayground and select a client-side OAuth flow and supply a Google OAuth 2.0 client ID that matches with client ID GraceTunes will use:

![](https://user-images.githubusercontent.com/11861195/77715227-4154a580-6f98-11ea-8907-ab5bec44fc56.png)

Select the Google OAuth2 API scopes:

![](https://user-images.githubusercontent.com/11861195/77716125-a8735980-6f9a-11ea-8ff2-78c6e5e00a50.png)

Click "Authorize APIs:" to start the OAuth 2.0 flow:

![](https://user-images.githubusercontent.com/11861195/77717554-05bcda00-6f9e-11ea-87cc-d5638afb1f82.png)

If prompted, select your gpmail.org account.

Click "Exchange authorization code for tokens" to get your OAuth 2.0 tokens:

![](https://user-images.githubusercontent.com/11861195/77717623-30a72e00-6f9e-11ea-8a6d-d2cbe10cf04a.png)


Taking the value of the `id_token` returned, make the following request to the GraceTunes v2 API:

```http
GET /api/v2/whoami
Accept: application/json
Authorization: Bearer {your_id_token}
```

#### Client app flow

An actual client (e.g., a React app, or iOS app) will use one of the many libraries to make a button like:

![](https://user-images.githubusercontent.com/11861195/77716737-15d3ba00-6f9c-11ea-9f84-1608f5208336.png)

trigger Google's OAuth2 flow (sign in / account selection / consent) and obtain the OAuth2 tokens with which they can authenticate themselves with GraceTunes.


### Authorization

Once authenticated, we retrieve (or create if it doesn't exist) the `User` record identified by the email in the JWT payload, and depending on the user's roles, different operations are permitted on different resources.


## TODO

Unit tests... :(