### PR TITLE
add instruction to upload songs with number chords

### DIFF
--- a/app/views/songs/_form.html.erb
+++ b/app/views/songs/_form.html.erb
@@ -47,6 +47,16 @@
 
   <div class="form-group required <%= highlight_if_errors(@song, :chord_sheet) %>">
     <%= f.label :chord_sheet, "Chord Sheet" %>
+    <br>
+    <i>*IMPORTANT*<br>
+      Please upload chord sheet with chords represented in numbers instead of letters.<br>
+      e.g. "I" as in capitalized roman number 1 instead of C<br>
+      Major chords: I II III IV V VI VII<br>
+      Minor chords: i ii iii iv v vi vii<br>
+      Suspended chords: Is IIs etc.<br>
+      Major 7 chords: I7 II7 etc.<br>
+      Diminished chords: Idim IIdim etc.<br>
+    </i>
     <%= f.text_area :chord_sheet, class: 'fixed-width form-control' %>
   </div>
 


### PR DESCRIPTION
### big picture
I want to change all our chord sheets from letter chords to number chords. This is so that when rendering a chord sheet in a specific key we can translate directly from numbers to that key, instead of using regex to transpose any key to any other key.

To transition all the chord sheets, I want to start from the upload page to "ensure" all new songs are created in number chords. This change adds instruction on the new/edit pages.

Meanwhile I'll try to work on a script to convert all the existing songs from letter chords to number chords.

song upload page looks like this
![Screenshot 2023-11-28 at 2 49 41 PM](https://github.com/PatrickF1/GraceTunes/assets/16906774/ca59f74e-d93c-4c5b-b728-891d1ca05ecd)
