### PR TITLE
Reconstruct user from cookie instead of loading from database

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,10 @@ class ApplicationController < ActionController::Base
 
   # Return a user constructed from the fields stored in the session, nil if one cannot be constructed
   def current_user
-    unless [:user_email, :name, :role].all? { |field| session.key?(field) }
-      return nil
+    return @current_user if @current_user
+    if [:user_email, :name, :role].all? { |field| session.key?(field) }
+        @current_user = User.new(email: session[:user_email], name: session[:name], role: session[:role])
     end
-    @current_user ||= User.new(email: session[:user_email], name: session[:name], role: session[:role])
   end
 
   def require_sign_in

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,9 @@ class ApplicationController < ActionController::Base
   # Return a user constructed from the fields stored in the session, nil if one cannot be constructed
   def current_user
     return @current_user if @current_user
+
     if [:user_email, :name, :role].all? { |field| session.key?(field) }
-        @current_user = User.new(email: session[:user_email], name: session[:name], role: session[:role])
+      @current_user = User.new(email: session[:user_email], name: session[:name], role: session[:role])
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,10 +7,12 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user
 
-  # returns the current user if signed in or nil if not signed in
+  # Return a user constructed from the fields stored in the session, nil if one cannot be constructed
   def current_user
-    return nil if session[:user_email].nil?
-    @current_user ||= User.find_by_email(session[:user_email])
+    unless [:user_email, :name, :role].all? { |field| session.key?(field) }
+      return nil
+    end
+    @current_user ||= User.new(email: session[:user_email], name: session[:name], role: session[:role])
   end
 
   def require_sign_in

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,13 +15,15 @@ class SessionsController < ApplicationController
     email = email.gsub('acts2.network', 'gpmail.org')
 
     # if person has never signed into GraceTunes before, create a user for him
-    if !@current_user = User.find_by_email(email)
+    unless (@current_user = User.find_by_email(email))
       full_name = user_info["name"].split('(')[0].strip # remove churchplant extention
       @current_user = User.create(email: email, name: full_name, role: Role::READER)
       logger.info "New user created: #{@current_user}"
     end
 
     session[:user_email] = @current_user.email
+    session[:full_name] = @current_user.name
+    session[:role] = @current_user.role
     redirect_to songs_path
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,7 @@ class SessionsController < ApplicationController
     end
 
     session[:user_email] = @current_user.email
-    session[:full_name] = @current_user.name
+    session[:name] = @current_user.name
     session[:role] = @current_user.role
     redirect_to songs_path
   end

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -19,7 +19,7 @@ class SongsController < ApplicationController
         songs = songs.select('id, artist, tempo, key, name, chord_sheet, spotify_uri')
 
         # store total number of songs after filtering
-        recordsFiltered = songs.length
+        records_filtered = songs.length
 
         # reorder
         songs = case params[:sort]
@@ -44,7 +44,7 @@ class SongsController < ApplicationController
         song_data = {
           draw: params[:draw].to_i,
           recordsTotal: Song.count,
-          recordsFiltered: recordsFiltered,
+          recordsFiltered: records_filtered,
           data: songs
         }
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
+  # Automatically append comments to SQL queries with runtime information tags
+  config.active_record.query_log_tags_enabled = true
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -4,19 +4,26 @@ class ApplicationControllerTest < ActionController::TestCase
 
   def setup
     # make sure user is signed in to access the app and can read
-    session[:user_email] = users(:reader).email
+    load_user_into_session(users(:reader))
   end
 
   def get_edit_privileges
-    session[:user_email] = users(:praise_member).email
+    load_user_into_session(users(:praise_member))
   end
 
   def get_deleting_privileges
-    session[:user_email] = users(:admin).email
+    load_user_into_session(users(:admin))
   end
 
   def sign_out
     session.delete(:user_email)
   end
 
+  private
+
+  def load_user_into_session(user)
+    session[:user_email] = user.email
+    session[:name] = user.name
+    session[:role] = user.role
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -24,18 +24,22 @@ class SessionsControllerTest < ApplicationControllerTest
     assert_redirected_to sign_in_path
   end
 
-  test "signing in should set user_email in the session and redirect to songs index" do
+  test "signing in should set user fields in the session and redirect to songs index" do
     sign_out
+    name = "A2N Member"
     email = "gpmember@gpmail.org"
     # manually mock the info that would be sent by Google servers
     request.env['omniauth.auth'] = {
       "info" => {
-          "name" => "Gracepoint Member",
-          "email" => email
+        "name" => name,
+        "email" => email
       }
     }
     get :create, params: { provider: "google_oauth2" }
-    assert_equal(email, session[:user_email] , "Email not set correctly in the session")
+    assert_equal(email, session[:user_email], "Email not set correctly in the session")
+    assert_not_nil(session[:name], "Name not set in the session")
+    assert_includes(Role.VALID_ROLES, session[:role], "A valid role was not set in the session")
+
     assert_redirected_to songs_path
   end
 
@@ -49,8 +53,8 @@ class SessionsControllerTest < ApplicationControllerTest
     email = "never-before-seen@gpmail.org"
     request.env['omniauth.auth'] = {
       "info" => {
-          "name" => "Never before seen",
-          "email" => email
+        "name" => "Never before seen",
+        "email" => email
       }
     }
     assert_difference('User.count', 1, "No new user was created") do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -38,7 +38,7 @@ class SessionsControllerTest < ApplicationControllerTest
     get :create, params: { provider: "google_oauth2" }
     assert_equal(email, session[:user_email], "Email not set correctly in the session")
     assert_not_nil(session[:name], "Name not set in the session")
-    assert_includes(Role.VALID_ROLES, session[:role], "A valid role was not set in the session")
+    assert_includes(Role::VALID_ROLES, session[:role], "A valid role was not set in the session")
 
     assert_redirected_to songs_path
   end


### PR DESCRIPTION
When I implemented support for user roles, I was wary of client-side tampering. Therefore, in my implementation, GT always read the users table for the user's role instead of storing and retrieving the role from the DB. Because every single action on GT requires checking the user's role, this forced a `select * from users` query for every single request. 

However, I learned that cookies are secure and tamper proof so this is completely unnecessary. To save unnecessary trips to the DB, this PR saves all the user's important fields in the cookie and reads them out of the cookie to re-construct the user. Turns out this only saves 1-4ms per request but it fun to implement and makes GT feel more professional 💪.