### PR TITLE
Optimize songs index SQL and update dev config

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -16,10 +16,10 @@ class SongsController < ApplicationController
         songs = songs.search_by_keywords(search_value) if search_value.present?
         songs = songs.where(key: params[:key]) if params[:key].present?
         songs = songs.where(tempo: params[:tempo]) if params[:tempo].present?
+        # get number of matching songs post filtering
+        records_filtered = songs.count
         songs = songs.select('id, artist, tempo, key, name, chord_sheet, spotify_uri')
 
-        # store total number of songs after filtering
-        records_filtered = songs.length
 
         # reorder
         songs = case params[:sort]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
+  # In the development environment your application's code is reloaded any time
+  # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
@@ -18,7 +18,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
+      'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
+  # Highlight code that triggered database queries in logs.
+  config.active_record.verbose_query_logs = true
+
   # Automatically append comments to SQL queries with runtime information tags
   config.active_record.query_log_tags_enabled = true
 
@@ -54,4 +57,10 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.enable_reloading = true
 
   # Do not eager load code on boot.
   config.eager_load = false
@@ -13,8 +13,10 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
+  # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
+    config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
@@ -53,6 +55,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.


### PR DESCRIPTION
The `songs.length` call in songs#index downloads all the matching songs at that point into an in-memory array and then calculates the length of the array. On the initial load of the GraceTunes songs index, there are no filters applied so it essentially downloaded the entire songs table. Testing showed this was adding 6-8 ms to every unique or un-cached songs index page load. The solution is to use `songs.count` which issues a simple COUNT query, cutting down the load time to around 1.5 ms un-cached.

I also pulled some settings from the Rails 7 dev config template into our dev config including
- ability to log to standard out instead of the log file
- logging the exact line each SQL query stemmed from
- raising error when before_action reference missing actions