### PR TITLE
Migrate emails in database to @acts.network

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,8 +12,6 @@ class SessionsController < ApplicationController
     user_info = request.env["omniauth.auth"]["info"]
     # Gmail emails are case insensitive so okay to lowercase it
     email = user_info["email"].downcase.strip
-    # Temporary hack to make new domain emails map to old user roles
-    email = email.gsub('acts2.network', 'gpmail.org')
 
     # if person has never signed into GraceTunes before, create a user for him
     unless (@current_user = User.find_by(email:))

--- a/db/migrate/20240219202443_change_email_domain_on_users_and_audits.rb
+++ b/db/migrate/20240219202443_change_email_domain_on_users_and_audits.rb
@@ -1,11 +1,11 @@
 class ChangeEmailDomainOnUsersAndAudits < ActiveRecord::Migration[7.1]
   def up
-    User.connection.execute("UPDATE users SET email = replace(email, '@gpmail.org',  '@acts2.network')")
-    Audited.audit_class.connection.execute("UPDATE audits SET user_id = replace(user_id, '@gpmail.org',  '@acts2.network')")
+    execute("UPDATE users SET email = replace(email, '@gpmail.org',  '@acts2.network')")
+    execute("UPDATE audits SET user_id = replace(user_id, '@gpmail.org',  '@acts2.network')")
   end
 
   def down
-    User.connection.execute("UPDATE users SET email = replace(email,  '@acts2.network', '@gpmail.org')")
-    Audited.audit_class.connection.execute("UPDATE audits SET user_id = replace(user_id, '@acts2.network', '@gpmail.org')")
+    execute("UPDATE users SET email = replace(email,  '@acts2.network', '@gpmail.org')")
+    execute("UPDATE audits SET user_id = replace(user_id, '@acts2.network', '@gpmail.org')")
   end
 end

--- a/db/migrate/20240219202443_change_email_domain_on_users_and_audits.rb
+++ b/db/migrate/20240219202443_change_email_domain_on_users_and_audits.rb
@@ -1,6 +1,11 @@
 class ChangeEmailDomainOnUsersAndAudits < ActiveRecord::Migration[7.1]
   def up
-    Users.connection.execute("UPDATE users SET email = replace(email, @gpmail.org, @acts2.network)")
-    Audits.connection.execute("UPDATE audits SET user_id = replace(user_id, @gpmail.org, @acts2.network)")
+    User.connection.execute("UPDATE users SET email = replace(email, '@gpmail.org',  '@acts2.network')")
+    Audited.audit_class.connection.execute("UPDATE audits SET user_id = replace(user_id, '@gpmail.org',  '@acts2.network')")
+  end
+
+  def down
+    User.connection.execute("UPDATE users SET email = replace(email,  '@acts2.network', '@gpmail.org')")
+    Audited.audit_class.connection.execute("UPDATE audits SET user_id = replace(user_id, '@acts2.network', '@gpmail.org')")
   end
 end

--- a/db/migrate/20240219202443_change_email_domain_on_users_and_audits.rb
+++ b/db/migrate/20240219202443_change_email_domain_on_users_and_audits.rb
@@ -1,0 +1,6 @@
+class ChangeEmailDomainOnUsersAndAudits < ActiveRecord::Migration[7.1]
+  def up
+    Users.connection.execute("UPDATE users SET email = replace(email, @gpmail.org, @acts2.network)")
+    Audits.connection.execute("UPDATE audits SET user_id = replace(user_id, @gpmail.org, @acts2.network)")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_03_181007) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_19_202443) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,32 +2,32 @@
 
 # Add GraceTunes team to users table with admin privileges so they can access all parts of the app
 User.create!(
-  email: "patrick.fong@gpmail.org",
+  email: "patrick.fong@acts2.network",
   name: "Patrick Fong",
   role: Role::ADMIN
 )
 User.create!(
-  email: "nathan.connor@gpmail.org",
+  email: "nathan.connor@acts2.network",
   name: "Nathan Connor",
   role: Role::ADMIN
 )
 User.create!(
-  email: "winston.kim@gpmail.org",
+  email: "winston.kim@acts2.network",
   name: "Winston Kim",
   role: Role::ADMIN
 )
 User.create!(
-  email: "steven.chang2@gpmail.org",
+  email: "steven.chang2@acts2.network",
   name: "Steven Chang",
   role: Role::ADMIN
 )
 User.create!(
-  email: "ivan.yung@gpmail.org",
+  email: "ivan.yung@acts2.network",
   name: "Ivan Yung",
   role: Role::ADMIN
 )
 User.create!(
-  email: "andrew.martinez@gpmail.org",
+  email: "andrew.martinez@acts2.network",
   name: "Andrew Martinez",
   role: Role::ADMIN
 )

--- a/lib/tasks/songs.rake
+++ b/lib/tasks/songs.rake
@@ -102,7 +102,7 @@ end
 def set_audit_user(&block)
   user = nil
   while user.nil?
-    puts "What is your GPmail? (e.g. patrick.fong@gpmail.org)"
+    puts "What is your Acts2 email? (e.g. patrick.fong@acts2.network)"
     user = User.find_by(email: $stdin.gets.strip)
   end
   Audited.audit_class.as_user(user, &block)

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -28,7 +28,7 @@ class SessionsControllerTest < ApplicationControllerTest
   test "signing in should set user fields in the session and redirect to songs index" do
     sign_out
     name = "A2N Member"
-    email = "gpmember@gpmail.org"
+    email = "gpmember@acts2.network"
     # manually mock the info that would be sent by Google servers
     request.env['omniauth.auth'] = {
       "info" => {
@@ -51,7 +51,7 @@ class SessionsControllerTest < ApplicationControllerTest
 
   test "create should create never-before-seen users as Readers" do
     sign_out
-    email = "never-before-seen@gpmail.org"
+    email = "never-before-seen@acts2.network"
     request.env['omniauth.auth'] = {
       "info" => {
         "name" => "Never before seen",

--- a/test/fixtures/praise_sets.yml
+++ b/test/fixtures/praise_sets.yml
@@ -1,5 +1,5 @@
 hillsong:
-  owner_email: "admin@gpmail.org"
+  owner_email: "admin@acts2.network"
   event_name: "Hillsong set"
   event_date: "2017-01-01"
   archived: true
@@ -11,7 +11,7 @@ hillsong:
       id: <%= ActiveRecord::FixtureSet.identify(:all_my_hope) %>
       key: "B"
 sws_05142017:
-  owner_email: "praise_member@gpmail.org"
+  owner_email: "praise_member@acts2.network"
   event_name: "Sunday Worship Service May 5, 2017"
   event_date: "2017-05-14"
   notes: |

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,12 +1,12 @@
 reader:
-  email: "random_member@gpmail.org"
+  email: "random_member@acts2.network"
   name: "Gracepoint Member"
   role: <%= Role::READER %>
 praise_member:
-  email: "praise_member@gpmail.org"
+  email: "praise_member@acts2.network"
   name: "Praise Member"
   role: <%= Role::PRAISE %>
 admin:
-  email: "admin@gpmail.org"
+  email: "admin@acts2.network"
   name: "GraceTunes Admin"
   role: <%= Role::ADMIN %>

--- a/test/models/praise_set_test.rb
+++ b/test/models/praise_set_test.rb
@@ -17,7 +17,7 @@ class PraiseSetTest < ActiveSupport::TestCase
 
   test 'should be invalid if owner does not exist' do
     set = praise_sets(:hillsong)
-    set.owner_email = 'doesntexist@gpmail.org'
+    set.owner_email = 'doesntexist@acts2.network'
     assert_not set.valid?, 'Was valid with an invalid owner_email'
   end
 


### PR DESCRIPTION
Followup to #156, which was a temporary hack.

Deploy process
1. turn on maintenance mode
2. update the `SECRET_KEY_BASE` environment variable to invalidate the current cookies containing gpmail.org as the email
3. `heroku run rake db:migrate` (https://devcenter.heroku.com/articles/getting-started-with-rails7#migrate-the-database)
4. inspect emails in Users and Audits table
5. turn off maintenance mode