### PR TITLE
API + web songs index: include bpm and standard_scan in list responses

### DIFF
--- a/app/controllers/api/songs_controller.rb
+++ b/app/controllers/api/songs_controller.rb
@@ -31,7 +31,7 @@ class API::SongsController < API::APIController
     songs = songs.where(key: params[:key]) if params[:key].present?
     songs = songs.where(tempo: params[:tempo]) if params[:tempo].present?
     songs = songs.where(category: params[:category]) if params[:category].present?
-    songs = songs.select('id, artist, tempo, key, name, chord_sheet, spotify_uri, category')
+    songs = songs.select('id, artist, tempo, bpm, key, name, chord_sheet, spotify_uri, category, standard_scan')
     matching_songs_count = songs.size
 
     # perform sorting

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -20,7 +20,7 @@ class SongsController < ApplicationController
         songs = songs.where(category: params[:category]) if params[:category].present?
         # get number of matching songs post filtering
         records_filtered = songs.count
-        songs = songs.select('id, artist, tempo, key, name, chord_sheet, spotify_uri, category')
+        songs = songs.select('id, artist, tempo, bpm, key, name, chord_sheet, spotify_uri, category, standard_scan')
 
         # reorder
         songs = case params[:sort]


### PR DESCRIPTION
## Description
What: Expose bpm and standard_scan on songs list responses.
Why: Clients need scan and numeric tempo without making per-song show calls. Previously only show returned these; list endpoints omitted them.
### Changes:
Add bpm and standard_scan to the SELECT in:
app/controllers/api/songs_controller.rb (index)
app/controllers/songs_controller.rb (index)
No schema or contract changes beyond adding fields. Song#as_json behavior unchanged (still excludes spotify_uri and adds spotify_widget_source).
### Endpoints affected:
GET /api/v1/songs: Items in data[] now include bpm and standard_scan.
GET /songs.json: Items in data[] (DataTables payload) now include bpm and standard_scan.
Backward compatibility: Additive fields only; existing consumers remain unaffected. Frontend columns mapping unchanged; extra fields are ignored unless used.
