### PR TITLE
feat(api): support Firebase Bearer token auth for API; add project ID config docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'pg_search'
 gem 'puma'
 gem 'rack-timeout'
 gem 'rails', '7.1.3.1'
+gem 'firebase_id_token' # verify Firebase Google ID tokens for API bearer auth
 gem 'sass-rails', '>= 5' # Use SCSS for stylesheets
 gem 'sdoc', group: :doc # bundle exec rake doc:rails generates the API under doc/api.
 gem 'terser', "~> 1.1" # JS minifier

--- a/README.md
+++ b/README.md
@@ -3,3 +3,43 @@
 ## Development
 
 Dev environment setup guide is on the GitHub wiki.
+
+## API authentication via Firebase (Bearer token)
+
+The API (under `api/v1/*`) accepts `Authorization: Bearer <Firebase ID token>` issued by Firebase Authentication (Google provider). The token is verified server-side using `firebase_id_token` and must include a verified email.
+
+### Configure allowed Firebase project IDs
+
+The verifier only accepts tokens from configured Firebase project IDs.
+
+- Single project:
+  - Set `FIREBASE_PROJECT_ID` to your Firebase project ID
+- Multiple projects:
+  - Set `FIREBASE_PROJECT_IDS` to a comma-separated list of project IDs
+
+Examples (Heroku):
+
+```bash
+# Single project
+heroku config:set FIREBASE_PROJECT_ID=tunes-11727 -a gracetunes
+
+# Multiple projects
+heroku config:set FIREBASE_PROJECT_IDS=tunes-11727,another-project -a gracetunes
+```
+
+Locally, export the same environment variables before starting the server.
+
+### Making requests
+
+Use the API routes, not the HTML routes. For example, list songs:
+
+```bash
+curl 'https://gracetunes.herokuapp.com/api/v1/songs' \
+  -H 'Authorization: Bearer <FIREBASE_ID_TOKEN>' \
+  -H 'Accept: application/json'
+```
+
+Notes:
+- Tokens must be valid Firebase ID tokens with `email_verified=true`.
+- If the email exists in `users`, that user's role is used. Otherwise, a transient user with role `Reader` is used (read-only access).
+

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -20,6 +20,11 @@ class API::APIController < ActionController::API
   def current_user
     return @current_user if @current_user
 
+    # Prefer Authorization: Bearer <firebase_id_token> when provided
+    bearer_user = current_user_from_bearer
+    return @current_user = bearer_user if bearer_user
+
+    # Fallback to session-based auth (used by web app)
     return unless [:user_email, :name, :role].all? { |field| session.key?(field) }
 
     @current_user = User.new(email: session[:user_email], name: session[:name], role: session[:role])
@@ -31,5 +36,40 @@ class API::APIController < ActionController::API
 
   def render_paginated_result(data, matching_count, total_count)
     render json: {data:, matching_count:, total_count:}
+  end
+
+  private
+
+  def current_user_from_bearer
+    token = bearer_token
+    return nil unless token
+
+    begin
+      # Certificates are cached by the gem; ensure they are available
+      FirebaseIdToken::Certificates.request
+      payload = FirebaseIdToken::Signature.verify(token)
+    rescue StandardError
+      payload = nil
+    end
+
+    return nil unless payload
+
+    # Only accept verified emails
+    email = payload["email"]&.downcase
+    name = payload["name"] || email
+    email_verified = payload["email_verified"] == true
+    return nil if email.nil? || !email_verified
+
+    # If a persisted user exists, use their role; otherwise default to Reader
+    persisted = User.find_by(email: email)
+    role = persisted&.role || Role::READER
+
+    User.new(email:, name:, role:)
+  end
+
+  def bearer_token
+    header = request.headers["Authorization"]
+    return nil unless header&.start_with?("Bearer ")
+    header.split(" ", 2).last
   end
 end

--- a/config/initializers/firebase_id_token.rb
+++ b/config/initializers/firebase_id_token.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Configure acceptable Firebase project IDs for Bearer token verification.
+# Set FIREBASE_PROJECT_IDS to a comma-separated list of allowed project IDs.
+
+FirebaseIdToken.configure do |config|
+  allowed = ENV.fetch('FIREBASE_PROJECT_IDS', '').split(',').map { |s| s.strip.presence }.compact
+  # If none specified, default to ENV['FIREBASE_PROJECT_ID'] if present
+  allowed = [ENV['FIREBASE_PROJECT_ID']] if allowed.empty? && ENV['FIREBASE_PROJECT_ID']
+  config.project_ids = allowed if allowed.any?
+end
+
+


### PR DESCRIPTION
## What
Adds Firebase Bearer token auth for API endpoints via firebase_id_token.
Verifies Authorization: Bearer <Firebase ID token>, builds current_user from token email.
Uses persisted user role if found; otherwise defaults to Reader (read-only). OmniAuth Google login remains for the web UI.

## Why
Enable programmatic access to api/v1/* without a browser session, using Firebase Google sign-in from clients.
Configuration
Allowed Firebase project IDs:
Single project: set FIREBASE_PROJECT_ID
Multiple projects: set FIREBASE_PROJECT_IDS (comma-separated)
Heroku examples:
```
heroku config:set FIREBASE_PROJECT_ID=tunes-11727 -a gracetunes
heroku config:set FIREBASE_PROJECT_IDS=tunes-11727,another-project -a gracetunes
```
Local dev: export the same env vars in your shell.
Usage
Use API routes (not HTML). Example:
```
    curl 'https://gracetunes.herokuapp.com/api/v1/songs' \
      -H 'Authorization: Bearer <FIREBASE_ID_TOKEN>' \
      -H 'Accept: application/json'
```
Token must be a valid Firebase ID token with email_verified=true.
## Deployment notes
New gem: firebase_id_token. Ensure bundler can install it. If you hit a bundler version mismatch:
Install required bundler: gem install bundler:2.4.22 && bundle _2.4.22_ install
Or upgrade the lockfile: gem install bundler && bundle update --bundler && bundle install
No DB migrations.

## Files changed
Gemfile: add firebase_id_token
config/initializers/firebase_id_token.rb: config via FIREBASE_PROJECT_ID(S)
app/controllers/api/api_controller.rb: Bearer token verification and current_user construction
README.md: configuration and usage instructions